### PR TITLE
Feat/percentage measurement

### DIFF
--- a/pkg/coordinator/tasks/tx_pool_latency_analysis/README.md
+++ b/pkg/coordinator/tasks/tx_pool_latency_analysis/README.md
@@ -32,6 +32,24 @@ The `tx_pool_latency_analysis` task evaluates latency of transaction processing 
 - **`tx_pool_latency_hdr_plot`**:
   The HDR plot of the transaction pool latency.
 
+- **`duplicated_p2p_event_count`**:
+  The number of duplicated P2P events.
+
+- **`missed_p2p_event_count`**:
+  The number of missed P2P events.
+
+- **`coordinated_omission_event_count`**:
+  The number of coordinated omission events.
+
+- **`duplicated_p2p_event_count_percentage`**:
+  The percentage of duplicated P2P events.
+
+- **`missed_p2p_event_count_percentage`**:
+  The percentage of missed P2P events.
+
+- **`coordinated_omission_event_count_percentage`**:
+  The percentage of coordinated omission events.
+
 ### Defaults
 
 ```yaml

--- a/pkg/coordinator/tasks/tx_pool_latency_analysis/task.go
+++ b/pkg/coordinator/tasks/tx_pool_latency_analysis/task.go
@@ -217,18 +217,24 @@ func (t *Task) Execute(ctx context.Context) error {
 	t.ctx.Outputs.SetVar("duplicated_p2p_event_count", result.DuplicatedP2PEventCount)
 	t.ctx.Outputs.SetVar("missed_p2p_event_count", result.NotReceivedP2PEventCount)
 	t.ctx.Outputs.SetVar("coordinated_omission_event_count", result.CoordinatedOmissionEventCount)
+	t.ctx.Outputs.SetVar("duplicated_p2p_event_count_percentage", result.DuplicatedP2PEventCount/result.TotalTxs)
+	t.ctx.Outputs.SetVar("missed_p2p_event_count_percentage", result.NotReceivedP2PEventCount/result.TotalTxs)
+	t.ctx.Outputs.SetVar("coordinated_omission_event_count_percentage", result.CoordinatedOmissionEventCount/result.TotalTxs)
 	t.ctx.Outputs.SetVar("hdr_plot", plot)
 
 	t.ctx.SetResult(types.TaskResultSuccess)
 
 	outputs := map[string]interface{}{
-		"tx_count":                          result.TotalTxs,
-		"min_latency_mus":                   minLatency,
-		"max_latency_mus":                   maxLatency,
-		"tx_pool_latency_hdr_plot":          plot,
-		"duplicated_p2p_event_count":        result.DuplicatedP2PEventCount,
-		"coordinated_omission_events_count": result.CoordinatedOmissionEventCount,
-		"missed_p2p_event_count":            result.NotReceivedP2PEventCount,
+		"tx_count":                                    result.TotalTxs,
+		"min_latency_mus":                             minLatency,
+		"max_latency_mus":                             maxLatency,
+		"tx_pool_latency_hdr_plot":                    plot,
+		"duplicated_p2p_event_count":                  result.DuplicatedP2PEventCount,
+		"coordinated_omission_events_count":           result.CoordinatedOmissionEventCount,
+		"missed_p2p_event_count":                      result.NotReceivedP2PEventCount,
+		"duplicated_p2p_event_count_percentage":       result.DuplicatedP2PEventCount / result.TotalTxs,
+		"missed_p2p_event_count_percentage":           result.NotReceivedP2PEventCount / result.TotalTxs,
+		"coordinated_omission_event_count_percentage": result.CoordinatedOmissionEventCount / result.TotalTxs,
 	}
 
 	outputsJSON, _ := json.Marshal(outputs)

--- a/pkg/coordinator/tasks/tx_pool_latency_analysis/task.go
+++ b/pkg/coordinator/tasks/tx_pool_latency_analysis/task.go
@@ -217,9 +217,9 @@ func (t *Task) Execute(ctx context.Context) error {
 	t.ctx.Outputs.SetVar("duplicated_p2p_event_count", result.DuplicatedP2PEventCount)
 	t.ctx.Outputs.SetVar("missed_p2p_event_count", result.NotReceivedP2PEventCount)
 	t.ctx.Outputs.SetVar("coordinated_omission_event_count", result.CoordinatedOmissionEventCount)
-	t.ctx.Outputs.SetVar("duplicated_p2p_event_count_percentage", result.DuplicatedP2PEventCount/result.TotalTxs)
-	t.ctx.Outputs.SetVar("missed_p2p_event_count_percentage", result.NotReceivedP2PEventCount/result.TotalTxs)
-	t.ctx.Outputs.SetVar("coordinated_omission_event_count_percentage", result.CoordinatedOmissionEventCount/result.TotalTxs)
+	t.ctx.Outputs.SetVar("duplicated_p2p_event_count_percentage", float64(result.DuplicatedP2PEventCount)/float64(result.TotalTxs))
+	t.ctx.Outputs.SetVar("missed_p2p_event_count_percentage", float64(result.NotReceivedP2PEventCount)/float64(result.TotalTxs))
+	t.ctx.Outputs.SetVar("coordinated_omission_event_count_percentage", float64(result.CoordinatedOmissionEventCount)/float64(result.TotalTxs))
 	t.ctx.Outputs.SetVar("hdr_plot", plot)
 
 	t.ctx.SetResult(types.TaskResultSuccess)
@@ -232,9 +232,9 @@ func (t *Task) Execute(ctx context.Context) error {
 		"duplicated_p2p_event_count":                  result.DuplicatedP2PEventCount,
 		"coordinated_omission_events_count":           result.CoordinatedOmissionEventCount,
 		"missed_p2p_event_count":                      result.NotReceivedP2PEventCount,
-		"duplicated_p2p_event_count_percentage":       result.DuplicatedP2PEventCount / result.TotalTxs,
-		"missed_p2p_event_count_percentage":           result.NotReceivedP2PEventCount / result.TotalTxs,
-		"coordinated_omission_event_count_percentage": result.CoordinatedOmissionEventCount / result.TotalTxs,
+		"duplicated_p2p_event_count_percentage":       float64(result.DuplicatedP2PEventCount) / float64(result.TotalTxs),
+		"missed_p2p_event_count_percentage":           float64(result.NotReceivedP2PEventCount) / float64(result.TotalTxs),
+		"coordinated_omission_event_count_percentage": float64(result.CoordinatedOmissionEventCount) / float64(result.TotalTxs),
 	}
 
 	outputsJSON, _ := json.Marshal(outputs)

--- a/pkg/coordinator/tasks/tx_pool_throughput_analysis/README.md
+++ b/pkg/coordinator/tasks/tx_pool_throughput_analysis/README.md
@@ -20,11 +20,39 @@ The `tx_pool_throughput_analysis` task evaluates the throughput of transaction p
 
 ### Outputs
 
-- **`tx_count`**:
-  The total number of transactions sent.
+- **`throughput_measures`**:
+  An array of throughput measurement objects, each containing:
+  - `load_tps`: The sending TPS for this measurement
+  - `processed_tps`: The actual processed TPS achieved
+  - `not_received_p2p_event_count`: Count of transactions that didn't receive P2P events
+  - `coordinated_omission_event_count`: Count of coordinated omission events
 
-- **`mean_tps_throughput`**:
-  The mean throughput (tps)
+- **`total_sent_tx`**:
+  The total number of transactions sent across all TPS measurements.
+
+- **`missed_p2p_event_count`**:
+  The total count of missed P2P events across all measurements.
+
+- **`coordinated_omission_event_count`**:
+  The total count of coordinated omission events across all measurements.
+
+- **`missed_p2p_event_count_percentage`**:
+  The percentage of transactions that missed P2P events.
+
+- **`coordinated_omission_event_count_percentage`**:
+  The percentage of transactions with coordinated omission events.
+
+- **`starting_tps`**:
+  The starting TPS value used in the test.
+
+- **`ending_tps`**:
+  The ending TPS value used in the test.
+
+- **`increment_tps`**:
+  The TPS increment value used between measurements.
+
+- **`duration_s`**:
+  The duration in seconds for each TPS measurement.
 
 ### Defaults
 

--- a/pkg/coordinator/tasks/tx_pool_throughput_analysis/task.go
+++ b/pkg/coordinator/tasks/tx_pool_throughput_analysis/task.go
@@ -138,6 +138,7 @@ func (t *Task) Execute(ctx context.Context) error {
 	t.logger.Infof("Iterating over the TPS range, starting TPS: %d, ending TPS: %d, increment TPS: %d",
 		t.config.StartingTPS, t.config.EndingTPS, t.config.IncrementTPS)
 
+	totalSentTx := 0
 	missedP2PEventCount := 0
 	totalCoordinatedOmissionEventCount := 0
 
@@ -159,6 +160,7 @@ func (t *Task) Execute(ctx context.Context) error {
 			CoordinatedOmissionEventCount: coordinatedOmissionEventCount,
 		})
 
+		totalSentTx += sendingTps * t.config.DurationS
 		missedP2PEventCount += notReceivedP2PEventCount
 		totalCoordinatedOmissionEventCount += coordinatedOmissionEventCount
 	}
@@ -174,15 +176,21 @@ func (t *Task) Execute(ctx context.Context) error {
 	t.ctx.Outputs.SetVar("ending_tps", t.config.EndingTPS)
 	t.ctx.Outputs.SetVar("increment_tps", t.config.IncrementTPS)
 	t.ctx.Outputs.SetVar("duration_s", t.config.DurationS)
+	t.ctx.Outputs.SetVar("total_sent_tx", totalSentTx)
+	t.ctx.Outputs.SetVar("missed_p2p_event_count_percentage", missedP2PEventCount/totalSentTx)
+	t.ctx.Outputs.SetVar("coordinated_omission_event_count_percentage", totalCoordinatedOmissionEventCount/totalSentTx)
+	// todo: aggiungere anche qui le percentuali di missed ecc
 
 	outputs := map[string]interface{}{
-		"throughput_measures":              throughoutMeasures,
-		"missed_p2p_event_count":           missedP2PEventCount,
-		"coordinated_omission_event_count": totalCoordinatedOmissionEventCount,
-		"starting_tps":                     t.config.StartingTPS,
-		"ending_tps":                       t.config.EndingTPS,
-		"increment_tps":                    t.config.IncrementTPS,
-		"duration_s":                       t.config.DurationS,
+		"throughput_measures":               throughoutMeasures,
+		"missed_p2p_event_count":            missedP2PEventCount,
+		"coordinated_omission_event_count":  totalCoordinatedOmissionEventCount,
+		"starting_tps":                      t.config.StartingTPS,
+		"ending_tps":                        t.config.EndingTPS,
+		"increment_tps":                     t.config.IncrementTPS,
+		"duration_s":                        t.config.DurationS,
+		"total_sent_tx":                     totalSentTx,
+		"missed_p2p_event_count_percentage": missedP2PEventCount / totalSentTx,
 	}
 
 	outputsJSON, _ := json.Marshal(outputs)

--- a/pkg/coordinator/tasks/tx_pool_throughput_analysis/task.go
+++ b/pkg/coordinator/tasks/tx_pool_throughput_analysis/task.go
@@ -179,7 +179,6 @@ func (t *Task) Execute(ctx context.Context) error {
 	t.ctx.Outputs.SetVar("total_sent_tx", totalSentTx)
 	t.ctx.Outputs.SetVar("missed_p2p_event_count_percentage", missedP2PEventCount/totalSentTx)
 	t.ctx.Outputs.SetVar("coordinated_omission_event_count_percentage", totalCoordinatedOmissionEventCount/totalSentTx)
-	// todo: aggiungere anche qui le percentuali di missed ecc
 
 	outputs := map[string]interface{}{
 		"throughput_measures":               throughoutMeasures,

--- a/pkg/coordinator/tasks/tx_pool_throughput_analysis/task.go
+++ b/pkg/coordinator/tasks/tx_pool_throughput_analysis/task.go
@@ -177,19 +177,20 @@ func (t *Task) Execute(ctx context.Context) error {
 	t.ctx.Outputs.SetVar("increment_tps", t.config.IncrementTPS)
 	t.ctx.Outputs.SetVar("duration_s", t.config.DurationS)
 	t.ctx.Outputs.SetVar("total_sent_tx", totalSentTx)
-	t.ctx.Outputs.SetVar("missed_p2p_event_count_percentage", missedP2PEventCount/totalSentTx)
-	t.ctx.Outputs.SetVar("coordinated_omission_event_count_percentage", totalCoordinatedOmissionEventCount/totalSentTx)
+	t.ctx.Outputs.SetVar("missed_p2p_event_count_percentage", float64(missedP2PEventCount)/float64(totalSentTx))
+	t.ctx.Outputs.SetVar("coordinated_omission_event_count_percentage", float64(totalCoordinatedOmissionEventCount)/float64(totalSentTx))
 
 	outputs := map[string]interface{}{
-		"throughput_measures":               throughoutMeasures,
-		"missed_p2p_event_count":            missedP2PEventCount,
-		"coordinated_omission_event_count":  totalCoordinatedOmissionEventCount,
-		"starting_tps":                      t.config.StartingTPS,
-		"ending_tps":                        t.config.EndingTPS,
-		"increment_tps":                     t.config.IncrementTPS,
-		"duration_s":                        t.config.DurationS,
-		"total_sent_tx":                     totalSentTx,
-		"missed_p2p_event_count_percentage": missedP2PEventCount / totalSentTx,
+		"throughput_measures":                         throughoutMeasures,
+		"missed_p2p_event_count":                      missedP2PEventCount,
+		"coordinated_omission_event_count":            totalCoordinatedOmissionEventCount,
+		"starting_tps":                                t.config.StartingTPS,
+		"ending_tps":                                  t.config.EndingTPS,
+		"increment_tps":                               t.config.IncrementTPS,
+		"duration_s":                                  t.config.DurationS,
+		"total_sent_tx":                               totalSentTx,
+		"missed_p2p_event_count_percentage":           float64(missedP2PEventCount) / float64(totalSentTx),
+		"coordinated_omission_event_count_percentage": float64(totalCoordinatedOmissionEventCount) / float64(totalSentTx),
 	}
 
 	outputsJSON, _ := json.Marshal(outputs)

--- a/playbooks/dev/tx-pool-check.yaml
+++ b/playbooks/dev/tx-pool-check.yaml
@@ -20,7 +20,7 @@ tasks:
   config:
     waitTime: 5
 - name: tx_pool_throughput_analysis
-  timeout: 5m
+  timeout: 15m
   title: "Check transaction pool throughput from 100 to 1000 TPS with 100 TPS increment, duration 2s per test"
   config:
     startingTps: 100
@@ -37,7 +37,7 @@ tasks:
     waitTime: 5
 - name: tx_pool_latency_analysis
   title: "Check transaction pool latency with 5.000 transactions in one second, duration 5s"
-  timeout: 5m
+  timeout: 15m
   config:
     tps: 5000
     durationS: 5
@@ -50,7 +50,7 @@ tasks:
   config:
     waitTime: 5
 - name: tx_pool_throughput_analysis
-  timeout: 15m
+  timeout: 30m
   title: "Check transaction pool throughput from 1000 to 5000 TPS with 500 TPS increment, duration 2s per test"
   config:
     startingTps: 1000


### PR DESCRIPTION
# Feat/percentage measurement

#### Overview

This PR introduces additional output metrics to the `tx_pool_latency_analysis` and `tx_pool_throughput_analysis` tasks to improve observability of P2P event anomalies and coordinated omission.

#### Key Changes

##### `tx_pool_latency_analysis`

* **Added Metrics:**

  * `duplicated_p2p_event_count`
  * `missed_p2p_event_count`
  * `coordinated_omission_event_count`
  * Percentage equivalents of the above metrics based on total transactions
* **README Updated:** Descriptions for the new metrics have been added.
* **Output Map Extended:** All new metrics are included in the output JSON.

##### `tx_pool_throughput_analysis`

* **Added Aggregated Metrics:**

  * `total_sent_tx`
  * `missed_p2p_event_count_percentage`
  * `coordinated_omission_event_count_percentage`
* **README Updated:** Reflects all new output fields and test parameters.
* **Output Map Extended:** All new fields added to final output JSON.

##### Playbook Updates

* **Increased Timeout Durations:**

  * `tx_pool_latency_analysis`: from 5m to 15m
  * `tx_pool_throughput_analysis`:

    * from 5m to 15m (low TPS range)
    * from 15m to 30m (high TPS range)
